### PR TITLE
Fix test

### DIFF
--- a/app/code/Magento/Theme/Model/View/Design.php
+++ b/app/code/Magento/Theme/Model/View/Design.php
@@ -6,7 +6,6 @@
 
 namespace Magento\Theme\Model\View;
 
-use Magento\Framework\App\ObjectManager;
 use Magento\Store\Model\ScopeInterface;
 
 /**
@@ -64,11 +63,6 @@ class Design implements \Magento\Framework\View\DesignInterface
     protected $_locale;
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface
-     */
-    protected $objectManager;
-
-    /**
      * @var \Magento\Framework\App\State
      */
     protected $_appState;
@@ -83,7 +77,6 @@ class Design implements \Magento\Framework\View\DesignInterface
      * @param \Magento\Framework\View\Design\Theme\FlyweightFactory $flyweightFactory
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Theme\Model\ThemeFactory $themeFactory
-     * @param \Magento\Framework\ObjectManagerInterface $objectManager
      * @param \Magento\Framework\App\State $appState
      * @param array $themes
      * @param \Magento\Framework\Locale\ResolverInterface $localeResolver
@@ -93,7 +86,6 @@ class Design implements \Magento\Framework\View\DesignInterface
         \Magento\Framework\View\Design\Theme\FlyweightFactory $flyweightFactory,
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Theme\Model\ThemeFactory $themeFactory,
-        \Magento\Framework\ObjectManagerInterface $objectManager,
         \Magento\Framework\App\State $appState,
         array $themes,
         \Magento\Framework\Locale\ResolverInterface $localeResolver = null
@@ -104,7 +96,6 @@ class Design implements \Magento\Framework\View\DesignInterface
         $this->_scopeConfig = $scopeConfig;
         $this->_appState = $appState;
         $this->_themes = $themes;
-        $this->objectManager = $objectManager;
         $this->localeResolver = $localeResolver ?: ObjectManager::getInstance()
             ->get(\Magento\Framework\Locale\ResolverInterface::class);
     }

--- a/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
+++ b/app/code/Magento/Theme/Test/Unit/Model/View/DesignTest.php
@@ -44,9 +44,9 @@ class DesignTest extends \PHPUnit_Framework_TestCase
     protected $defaultTheme = 'anyName4Theme';
 
     /**
-     * @var \Magento\Framework\ObjectManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Framework\Locale\ResolverInterface|\PHPUnit_Framework_MockObject_MockObject
      */
-    private $objectManager;
+    private $localeResolver;
 
     /**
      * @var Design::__construct
@@ -61,17 +61,17 @@ class DesignTest extends \PHPUnit_Framework_TestCase
         );
         $this->config = $this->getMockForAbstractClass(\Magento\Framework\App\Config\ScopeConfigInterface::class);
         $this->themeFactory = $this->getMock(\Magento\Theme\Model\ThemeFactory::class, ['create'], [], '', false);
-        $this->objectManager = $this->getMockForAbstractClass(\Magento\Framework\ObjectManagerInterface::class);
         $this->state = $this->getMock(\Magento\Framework\App\State::class, [], [], '', false);
         $themes = [Design::DEFAULT_AREA => $this->defaultTheme];
+        $this->localeResolver = $this->getMock(\Magento\Framework\Locale\ResolverInterface::class, [], [], '', false);
         $this->model = new Design(
             $this->storeManager,
             $this->flyweightThemeFactory,
             $this->config,
             $this->themeFactory,
-            $this->objectManager,
             $this->state,
-            $themes
+            $themes,
+            $this->localeResolver
         );
     }
 
@@ -151,13 +151,9 @@ class DesignTest extends \PHPUnit_Framework_TestCase
     {
         $locale = 'locale';
         $area = Design::DEFAULT_AREA;
-        $localeMock = $this->getMockForAbstractClass(\Magento\Framework\Locale\ResolverInterface::class);
-        $localeMock->expects($this->once())
+        $this->localeResolver->expects($this->once())
             ->method('getLocale')
             ->will($this->returnValue($locale));
-        $this->objectManager->expects($this->once())
-            ->method('get')
-            ->will($this->returnValue($localeMock));
         $this->state->expects($this->any())
             ->method('getAreaCode')
             ->willReturn($area);


### PR DESCRIPTION
It seems to work. I have been looking at other calls to the localeResolver function, but I don't think changing the test would break anything. I have removed objectManager completely, but maybe they want to keep their test on line 158. But we have to introduce Objectmanager there then(so not in the constructor).

Don't merge this version, this was just to show the changes.